### PR TITLE
Remove duplicate type definitions

### DIFF
--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -114,13 +114,6 @@ TODO
 struct ReservoirLevelLimitConstraint <: PSI.ConstraintType end
 
 """
-Struct to model time-coupling of stored volume
-
-TODO
-"""
-struct ReservoirInventoryConstraint <: PSI.ConstraintType end
-
-"""
 Struct to model the final (target) volume/head storage constraint
 
 TODO

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -57,11 +57,4 @@ Docs abbreviation: ``E^\\text{hy,out}``
 """
 struct HydroEnergyOutput <: PSI.AuxVariableType end
 
-"""
-Struct to dispatch the creation of a variable for the turbined outflow
-
-Docs abbreviation: ``f^\\text{Tu}``
-"""
-struct HydroTurbineFlowRateVariable <: PSI.VariableType end
-
 PSI.should_write_resulting_value(::Type{HydroTurbineFlowRateVariable}) = false


### PR DESCRIPTION
These two types were defined twice, triggering Julia warnings.
