### PR TITLE
Bump version to 0.17.0 and PowerSimulations compat to ^0.36

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 [compat]
 Dates = "1"
 InfrastructureSystems = "3"
-PowerSimulations = "^0.36"
+PowerSimulations = "0.35 - 0.36"
 PowerSystems = "5"
 julia = "^1.10"
 JuMP = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HydroPowerSimulations"
 uuid = "fc1677e0-6ad7-4515-bf3a-bd6bf20a0b1b"
-version = "0.16.0"
+version = "0.17.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -12,7 +12,7 @@ PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 [compat]
 Dates = "1"
 InfrastructureSystems = "3"
-PowerSimulations = "^0.35"
+PowerSimulations = "^0.36"
 PowerSystems = "5"
 julia = "^1.10"
 JuMP = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 [compat]
 Dates = "1"
 InfrastructureSystems = "3"
-PowerSimulations = "0.35 - 0.36"
+PowerSimulations = "^0.36"
 PowerSystems = "5"
 julia = "^1.10"
 JuMP = "1"


### PR DESCRIPTION
Thanks for opening a PR to HydroPowerSimulations.jl, please take note of the following when making a PR:

Check the [contributor guidelines](https://sienna-platform.github.io/HydroPowerSimulations.jl/stable/code_base_developer_guide/developer/)

## Description

Bumps `HydroPowerSimulations` to `0.17.0` and updates the `PowerSimulations` compat bound from `^0.35` to `^0.36` to track the newly released `PowerSimulations 0.36.0`.

- **Project.toml**: `version = "0.17.0"`, `PowerSimulations = "^0.36"`

The earlier CI failure on this branch was caused by a stale General registry cache that did not yet contain `PowerSimulations 0.36.0`; the registry has since been updated, so the original constraint is correct.